### PR TITLE
Enable CI Docker image push on master merge

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,8 +13,7 @@ jobs:
   build:
 
     env: 
-      ENABLE_DOCKER_PUSH: false
-#      ENABLE_DOCKER_PUSH: ${{ github.repository_owner == 'PlummersSoftwareLLC' && github.ref == 'refs/heads/master' }}
+      ENABLE_DOCKER_PUSH: ${{ github.repository_owner == 'PlummersSoftwareLLC' && github.ref == 'refs/heads/master' }}
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This enables the push of Docker images to Docker Hub after a merge to master.